### PR TITLE
fix: clear LD_PRELOAD so shell/child processes work on Termux

### DIFF
--- a/bin/opencode
+++ b/bin/opencode
@@ -36,7 +36,7 @@ if [[ "$LATEST" =~ ^[0-9]+\.[0-9]+\.[0-9]+([-.][0-9A-Za-z.-]+)?$ ]] && [ "$CURRE
   echo "Warning: update failed; using the installed version." >&2
 fi
 
-export LD_PRELOAD="$OPENCODE_DIR/ld-musl-aarch64.so.1"
+unset LD_PRELOAD
 export LD_LIBRARY_PATH="$OPENCODE_DIR"
 export SSL_CERT_FILE=/data/data/com.termux/files/usr/etc/tls/cert.pem
 


### PR DESCRIPTION
## Summary

Running commands in OpenCode's shell on Termux hangs or segfaults (issue #2). The cause is the wrapper leaking musl's libc into every child process via `LD_PRELOAD`. This PR clears it, which makes both OpenCode's launch and its child processes work.

## Root cause

`bin/opencode` currently does:

```bash
export LD_PRELOAD="$OPENCODE_DIR/ld-musl-aarch64.so.1"
export LD_LIBRARY_PATH="$OPENCODE_DIR"
```

`LD_PRELOAD` is inherited by every process OpenCode spawns. Children (bash, python, ls, git) are bionic-linked Termux binaries, and force-loading musl's libc into them breaks them at startup:

```
$ LD_PRELOAD=$HOME/.opencode/ld-musl-aarch64.so.1 bash -c 'echo hi'
Segmentation fault
```

The preload is not needed to run OpenCode itself — the binary's interpreter is already patched to the musl loader by `install.js`, and `LD_LIBRARY_PATH` resolves the remaining libs:

```
$ env -u LD_PRELOAD LD_LIBRARY_PATH=$HOME/.opencode $HOME/.opencode/opencode --version
1.18.15
```

It must be *cleared*, not just removed: Termux shells export `LD_PRELOAD=$PREFIX/lib/libtermux-exec-ld-preload.so`, which would otherwise leak into OpenCode's launch and crash it (the musl interpreter can't relocate that bionic library).

## Diff

```diff
--- a/bin/opencode
+++ b/bin/opencode
@@ -36,7 +36,7 @@ if [[ "$LATEST" =~ ^[0-9]+\.[0-9]+\.[0-9]+([-.][0-9A-Za-z.-]+)?$ ]] && [ "$CURRENT" != "$LATEST" ]; then
   echo "Warning: update failed; using the installed version." >&2
 fi

-export LD_PRELOAD="$OPENCODE_DIR/ld-musl-aarch64.so.1"
+unset LD_PRELOAD
 export LD_LIBRARY_PATH="$OPENCODE_DIR"
 export SSL_CERT_FILE=/data/data/com.termux/files/usr/etc/tls/cert.pem

```

## Testing

- Before: `echo hi` / `ls` / `python --version` in the shell hang until timeout.
- After: all return instantly (`hi`, listing, `Python 3.14.6`).
- Launch verified with `--version` under a clean env and via the wrapper.

## Notes / follow-up

- `LD_LIBRARY_PATH=$HOME/.opencode` is still inherited by children; it only contains `libc.musl`/`libgcc_s`/`libstdc++`, which bionic children don't usually link, but the cleanest long-term option is `patchelf --set-rpath '$ORIGIN'` in `install.js` so children inherit nothing.
- Once merged, re-running `opencode` (or its auto-update) repairs existing installs, since the wrapper is what launches the runtime.

Fixes #2
